### PR TITLE
Make java version detection using `java -version` more robust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,9 @@ Authors@R: c(
     person("Hadley", "Wickham", , "hadley@posit.co", role = "ctb",
            comment = "use_java feature suggestion and PR review"),
     person("Enrique", "Mondragon-Estrada", , "enriquemondragon@proton.me", role = "ctb",
-           comment = c(ORCID = "0009-0004-5592-1728"))
+           comment = c(ORCID = "0009-0004-5592-1728")),
+    person("Jonas", "Lieth", , "jonas.lieth@gesis.org", role = c("aut", "cre", "cph"),
+           comment = c(ORCID = "0000-0002-3451-3176"))
   )
 Description: Quickly install 'Java Development Kit (JDK)' without
     administrative privileges and set environment variables in current R

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,13 @@
 
 - `force` argument in `java_download()`. When set to `TRUE`, allows to overwrite the distribution file if it already exist in the cache.
 
+## Improvements
+
+- better command line `Java` detection (thanks to Jonas Lieth)
+
 # rJavaEnv 0.2.2 (2024-09-13)
 
-* Hot fix: improve robustness of setting Java environment in the current session with either `use_java()` or `java_quick_install()`. See bug fix below.
+* Hot fix: improve robustness of setting `Java` environment in the current session with either `use_java()` or `java_quick_install()`. See bug fix below.
 
 * Bug fix: Setting Java environment via `rJava::.jniInitialized()` rendered impossible changing Java version for `rJava`-dependent packages, because it somehow pre-initialised `rJava`
 

--- a/R/java_env.R
+++ b/R/java_env.R
@@ -331,8 +331,8 @@ java_check_version_system <- function(
 
   # extract Java version
   java_ver_string <- java_ver[[1]]
-  matches <- gregexpr('(?<=\\b(?:openjdk|java) version \")[0-9]{1,2}', java_ver_string, perl = TRUE)
-  major_java_ver <- regmatches(java_ver_string, matches)[[1]]
+  matches <- regexec('(openjdk|java) (version )?(\\\")?([0-9]{1,2})', java_ver_string)
+  major_java_ver <- regmatches(java_ver_string, matches)[[1]][5]
 
   # fix 1 to 8, as Java 8 prints "1.8"
   if (major_java_ver == "1") {

--- a/R/java_env.R
+++ b/R/java_env.R
@@ -17,20 +17,20 @@
 #'   project_path = tempdir(),
 #'   autoset_java_env = FALSE
 #' )
-#' 
+#'
 #' # now manually set the JAVA_HOME and PATH environment variables in current session
 #' java_env_set(
 #'   where = "session",
 #'   java_home = java_home
 #' )
-#' 
+#'
 #' # or set JAVA_HOME and PATH in the spefific projects' .Rprofile
 #' java_env_set(
 #'   where = "session",
 #'   java_home = java_home,
 #'   project_path = tempdir()
 #' )
-#' 
+#'
 #' }
 java_env_set <- function(
   where = c("session", "both", "project"),
@@ -38,13 +38,13 @@ java_env_set <- function(
   project_path = NULL,
   quiet = FALSE
 ) {
-  
+
   where <- match.arg(where)
   checkmate::assertString(java_home)
   checkmate::assertFlag(quiet)
-  
-  
-  
+
+
+
   if (where %in% c("session", "both")) {
     java_env_set_session(java_home)
     if (!quiet) {
@@ -54,16 +54,16 @@ java_env_set <- function(
       ))
     }
   }
-  
+
   rje_consent_check()
   if (where %in% c("project", "both")) {
     # consistent with renv behavior for using
     # the current working directory by default
     # https://github.com/rstudio/renv/blob/d6bced36afa0ad56719ca78be6773e9b4bbb078f/R/init.R#L69-L86
     project_path <- ifelse(is.null(project_path), getwd(), project_path)
-    
+
     java_env_set_rprofile(java_home, project_path = project_path)
-    
+
     if (!quiet) {
       cli::cli_alert_success(c(
         "Current R Project/Working Directory: ",
@@ -83,14 +83,14 @@ java_env_set <- function(
 #' @importFrom utils installed.packages
 #'
 java_env_set_session <- function(java_home) {
-  
+
   # check if rJava is installed and alread initialized
   if (any(utils::installed.packages()[, 1] == "rJava")) {
     if( "rJava" %in% loadedNamespaces() == TRUE ) {
       cli::cli_inform(c("!" = "You have `rJava` R package loaded in the current session. If you have already initialised it directly with ``rJava::.jinit()` or via your Java-dependent R package in the current session, you may not be able to switch to a different `Java` version unless you restart R. `Java` version can only be set once per session for packages that rely on `rJava`. Unless you restart the R session or run your code in a new R subprocess using `targets` or `callr`, the new `JAVA_HOME` and `PATH` will not take effect."))
     }
   }
-  
+
   Sys.setenv(JAVA_HOME = java_home)
 
   old_path <- Sys.getenv("PATH")
@@ -301,7 +301,7 @@ java_check_version_cmd <- function(
 #' @inheritParams java_check_version_cmd
 #' @return A `character` vector of length 1 containing the major Java version.
 #' @keywords internal
-#' 
+#'
 java_check_version_system <- function(
   quiet
 ) {
@@ -331,9 +331,9 @@ java_check_version_system <- function(
 
   # extract Java version
   java_ver_string <- java_ver[[1]]
-  matches <- gregexpr('(?<=openjdk version \\\")[0-9]{1,2}(?=\\.)', java_ver_string, perl = TRUE)
+  matches <- gregexpr('(?<=\\b(?:openjdk|java) version \")[0-9]{1,2}', java_ver_string, perl = TRUE)
   major_java_ver <- regmatches(java_ver_string, matches)[[1]]
-  
+
   # fix 1 to 8, as Java 8 prints "1.8"
   if (major_java_ver == "1") {
     major_java_ver <- "8"
@@ -361,7 +361,7 @@ java_env_unset <- function(
     quiet = FALSE
 ) {
   rje_consent_check()
-  
+
   # Resolve the project path
   # consistent with renv behavior
   # https://github.com/rstudio/renv/blob/d6bced36afa0ad56719ca78be6773e9b4bbb078f/R/init.R#L69-L86


### PR DESCRIPTION
As discussed I took another look at the java version strings of different java distributions and found the following:

```
Java temurin 22     : openjdk 22.0.2 2024-07-16
Java zulu 22        : openjdk 22.0.2 2024-07-16
Java adopt 22       : openjdk 22.0.2 2024-07-16
Java liberica 22    : openjdk 22.0.2 2024-07-16
Java microsoft 17   : openjdk 17.0.10 2024-01-16 LTS
Java corretto 22    : openjdk 22.0.2 2024-07-16
Java semeru 22      : openjdk 22.0.2 2024-07-16
Java sapmachine 22  : openjdk 22.0.2 2024-07-16
Java oracle 22      : java 22 2024-03-19
```

So most distributions are pretty standardized, but Oracle thinks otherwise.

The pull requests changes the java version regex from:

```
(?<=openjdk version \\\")[0-9]{1,2}(?=\\.)
```

to

```
(?<=\\b(?:openjdk|java) version \")[0-9]{1,2}
```

There are three important changes:

1. Obviously, I added "java" in a non-capturing group
2. I removed the positive lookbehind at the end so that single version specifications, which - like above - do not have a dot behind it, are captured.
3. I added a word boundary before the version string so that the version is detected even if there is something else going on (on my machine this fixes #51)