### PR TITLE
replace getOption major java ver with java_valid_versions function

### DIFF
--- a/R/java_install.R
+++ b/R/java_install.R
@@ -40,7 +40,7 @@ java_install <- function(
 
   platforms <- c("windows", "linux", "macos")
   architectures <- c("x64", "aarch64", "arm64")
-  java_versions <- getOption("rJavaEnv.valid_major_java_versions")
+  java_versions <- java_valid_versions()
 
   # Extract information from the file name
   filename <- basename(java_distrib_path)

--- a/R/java_unpack.R
+++ b/R/java_unpack.R
@@ -1,48 +1,51 @@
 #' Unpack a Java distribution file into cache directory
-#' 
+#'
 #' @description
 #' Unpack the Java distribution file into cache directory and return the path to the unpacked Java directory with Java binaries.
-#' 
-#' 
+#'
+#'
 #' @inheritParams java_install
 #' @inheritParams global_quiet_param
 #' @return A `character` vector containing of length 1 containing the path to the unpacked Java directory.
 #' @export
 #' @examples
 #' \dontrun{
-#' 
+#'
 #' # set cache dir to temporary directory
 #' options(rJavaEnv.cache_path = tempdir())
-#' 
+#'
 #' # download Java 17 distrib and unpack it into cache dir
 #' java_17_distrib <- java_download(version = "17")
 #' java_home <- java_unpack(java_distrib_path = java_17_distrib)
-#' 
+#'
 #' # set the JAVA_HOME environment variable in the current session
 #' # to the cache dir without touching any files in the current project directory
 #' java_env_set(where = "session", java_home = java_home)
 #' }
-#' 
+#'
 java_unpack <- function(
   java_distrib_path,
   quiet = FALSE
 ) {
   platforms <- c("windows", "linux", "macos")
   architectures <- c("x64", "aarch64", "arm64")
-  java_versions <- getOption("rJavaEnv.valid_major_java_versions")
+  java_versions <- java_valid_versions()
 
   # Extract information from the file name
   filename <- basename(java_distrib_path)
   parts <- strsplit(gsub("\\.tar\\.gz|\\.zip", "", filename), "-")[[1]]
 
   # Guess the version, architecture, and platform
-    version <- parts[parts %in% java_versions][1]
-    arch <- parts[parts %in% architectures][1]
-    platform <- parts[parts %in% platforms][1]
+  version <- parts[parts %in% java_versions][1]
+  arch <- parts[parts %in% architectures][1]
+  platform <- parts[parts %in% platforms][1]
 
-  if (is.na(version)) cli::cli_abort("Unable to detect Java version from filename.")
-  if (is.na(arch)) cli::cli_abort("Unable to detect architecture from filename.")
-  if (is.na(platform)) cli::cli_abort("Unable to detect platform from filename.")
+  if (is.na(version))
+    cli::cli_abort("Unable to detect Java version from filename.")
+  if (is.na(arch))
+    cli::cli_abort("Unable to detect architecture from filename.")
+  if (is.na(platform))
+    cli::cli_abort("Unable to detect platform from filename.")
 
   # Create the installation path in the package cache
   cache_path <- getOption("rJavaEnv.cache_path")
@@ -87,12 +90,19 @@ java_unpack <- function(
     }
 
     # Move the extracted files to the installation path
-    file.copy(list.files(extracted_dir, full.names = TRUE), installed_path, recursive = TRUE)
+    file.copy(
+      list.files(extracted_dir, full.names = TRUE),
+      installed_path,
+      recursive = TRUE
+    )
 
     # Clean up temporary directory
     unlink(temp_dir, recursive = TRUE)
   } else {
-    if (!quiet) cli::cli_inform("Java distribution {filename} already unpacked at {.path {installed_path}}")
+    if (!quiet)
+      cli::cli_inform(
+        "Java distribution {filename} already unpacked at {.path {installed_path}}"
+      )
   }
   return(installed_path)
 }

--- a/R/use_java.R
+++ b/R/use_java.R
@@ -1,34 +1,34 @@
 #' Install specified Java version and set the `JAVA_HOME` and `PATH` environment variables in current R session
-#' 
+#'
 #' @description
 #' Using specified Java version, set the `JAVA_HOME` and `PATH` environment variables in the current R session. If Java distribtuion has not been downloaded yet, download it. If it was not installed into cache directory yet, install it there and then set the environment variables. This is intended as a quick and easy way to use different Java versions in R scripts that are in the same project, but require different Java versions. For example, one could use this in scripts that are called by `targets` package or `callr` package.
 #' @inheritParams java_download
 #' @inheritParams java_install
 #' @inheritParams global_quiet_param
 #' @return `NULL`. Prints the message that Java was set in the current R session if `quiet` is set to `FALSE`.
-#' 
+#'
 #' @export
-#' 
+#'
 #' @examples
 #' \dontrun{
-#' 
+#'
 #' # set cache directory for Java to be in temporary directory
 #' options(rJavaEnv.cache_path = tempdir())
-#' 
+#'
 #' # install and set Java 8 in current R session
 #' use_java(8)
 #' # check Java version
 #' "8" == java_check_version_cmd(quiet = TRUE)
 #' "8" == java_check_version_rjava(quiet = TRUE)
-#' 
+#'
 #' # install and set Java 17 in current R session
 #' use_java(17)
 #' # check Java version
 #' "17" == java_check_version_cmd(quiet = TRUE)
 #' "17" == java_check_version_rjava(quiet = TRUE)
-#' 
+#'
 #' }
-#' 
+#'
 use_java <- function(
   version = NULL,
   distribution = "Corretto",
@@ -36,10 +36,10 @@ use_java <- function(
   platform = platform_detect()$os,
   arch = platform_detect()$arch,
   quiet = TRUE
-){
+) {
   checkmate::check_vector(version, len = 1)
   version <- as.character(version)
-  checkmate::assert_choice(version, getOption("rJavaEnv.valid_major_java_versions"))
+  checkmate::assert_choice(version, java_valid_versions())
 
   java_distrib_path <- java_download(
     version = version,
@@ -62,7 +62,9 @@ use_java <- function(
   )
 
   if (!quiet) {
-    cli::cli_alert_success("Java version {version} was set in the current R session")
+    cli::cli_alert_success(
+      "Java version {version} was set in the current R session"
+    )
   }
   invisible()
 }

--- a/vignettes/multiple-java-with-targets-callr.qmd
+++ b/vignettes/multiple-java-with-targets-callr.qmd
@@ -25,13 +25,17 @@ First, load the package and check the valid major versions of `Java`:
 
 ```{r}
 library(rJavaEnv)
-getOption("rJavaEnv.valid_major_java_versions")
+java_valid_versions()
 ```
 
 
 ```
-[1] "8"  "11" "17" "21" "22"
+[1] "8"  "11" "15" "16" "17" "18" "19" "20" "21" "22" "23" "24"
 ```
+
+::: {.callout-note}
+The available versions of `Java` depend on your OS and architecture, so you might see a shorter list on your system.
+:::
 
 Now select any two or three versions and run `use_java()`, checking every time that correct java was set in the current environment.
 


### PR DESCRIPTION
@chainsawriot here is the suggestion for fixing #74 .

I am having second thoughts on how a hypothetical `bypass_version_check` could be implemented. As the `java_versions` variable in `java_install` and `java_unpack` is used mostly for matching of versions:

https://github.com/e-kotov/rJavaEnv/blob/dc8eff7424c8c57a1264095824277cffcee43cc8/R/java_install.R#L50-L52

There could be an argument for manual setting of valid versions to match against.