### PR TITLE
Fix live Java checks and Temurin discovery

### DIFF
--- a/.github/workflows/java-live-tests.yml
+++ b/.github/workflows/java-live-tests.yml
@@ -52,6 +52,12 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Log Java diagnostics
+        shell: bash
+        run: |
+          java -version || true
+          Rscript -e 'cat(Sys.getenv("JAVA_HOME"), "\n")'
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/R/internal_utilities.R
+++ b/R/internal_utilities.R
@@ -73,6 +73,63 @@ read_json_url <- function(url, max_simplify_lvl = "data_frame") {
   RcppSimdJson::fparse(content, max_simplify_lvl = max_simplify_lvl)
 }
 
+#' Build environment variables for a Java subprocess
+#'
+#' @param java_home Path to Java home directory.
+#' @param rjava Logical. Whether the subprocess will initialize rJava.
+#'
+#' @return Named character vector of environment variables.
+#' @keywords internal
+#' @noRd
+java_subprocess_env <- function(java_home, rjava = FALSE) {
+  checkmate::assert_string(java_home)
+  checkmate::assert_logical(rjava, len = 1)
+
+  env_vars <- Sys.getenv()
+  java_bin <- file.path(java_home, "bin")
+  old_path <- env_vars[["PATH"]]
+
+  env_vars["JAVA_HOME"] <- java_home
+  env_vars["PATH"] <- paste(java_bin, old_path, sep = .Platform$path.sep)
+
+  if (!isTRUE(rjava)) {
+    return(env_vars)
+  }
+
+  sysname <- Sys.info()[["sysname"]]
+  libjvm_path <- get_libjvm_path(java_home)
+  if (is.null(libjvm_path)) {
+    return(env_vars)
+  }
+
+  jvm_lib_dir <- dirname(libjvm_path)
+
+  if (identical(sysname, "Linux")) {
+    old_ld <- env_vars[["LD_LIBRARY_PATH"]]
+    if (is.na(old_ld)) {
+      old_ld <- ""
+    }
+    env_vars["JAVA_LD_LIBRARY_PATH"] <- jvm_lib_dir
+    env_vars["LD_LIBRARY_PATH"] <- if (nzchar(old_ld)) {
+      paste(jvm_lib_dir, old_ld, sep = .Platform$path.sep)
+    } else {
+      jvm_lib_dir
+    }
+  } else if (identical(sysname, "Darwin")) {
+    old_dyld <- env_vars[["DYLD_LIBRARY_PATH"]]
+    if (is.na(old_dyld)) {
+      old_dyld <- ""
+    }
+    env_vars["DYLD_LIBRARY_PATH"] <- if (nzchar(old_dyld)) {
+      paste(jvm_lib_dir, old_dyld, sep = .Platform$path.sep)
+    } else {
+      jvm_lib_dir
+    }
+  }
+
+  env_vars
+}
+
 #' Read lines from a URL or file
 #'
 #' Helper function to read lines, mainly for testability.
@@ -148,44 +205,9 @@ urls_test_all <- function() {
 java_version_check_rscript <- function(java_home) {
   result <- tryCatch(
     {
-      Sys.setenv(JAVA_HOME = java_home)
-
-      old_path <- Sys.getenv("PATH")
-      new_path <- file.path(java_home, "bin")
-      Sys.setenv(PATH = paste(new_path, old_path, sep = .Platform$path.sep))
-
-      # On Linux, find and dynamically load libjvm.so
-      if (Sys.info()["sysname"] == "Linux") {
-        libjvm_path <- get_libjvm_path(java_home)
-
-        if (!is.null(libjvm_path) && file.exists(libjvm_path)) {
-          tryCatch(
-            dyn.load(libjvm_path),
-            error = function(e) {
-              # Use base message to avoid dependency issues in the isolated script
-              message(sprintf(
-                "Found libjvm.so at '%s' but failed to load it: %s",
-                libjvm_path,
-                e$message
-              ))
-            }
-          )
-        } else {
-          message(sprintf(
-            "Could not find libjvm.so within the provided JAVA_HOME: %s",
-            java_home
-          ))
-        }
-      }
-
       suppressWarnings(rJava::.jinit())
-      suppressWarnings(
-        java_version <- rJava::.jcall(
-          "java.lang.System",
-          "S",
-          "getProperty",
-          "java.version"
-        )
+      java_version <- suppressWarnings(
+        rJava::.jcall("java.lang.System", "S", "getProperty", "java.version")
       )
 
       message <- cli::format_message(
@@ -200,6 +222,28 @@ java_version_check_rscript <- function(java_home) {
   )
 
   return(result)
+}
+
+#' Parse major Java version from a java.version string
+#'
+#' @param java_ver_str Character string containing Java version.
+#'
+#' @return Character scalar major version or NULL.
+#' @keywords internal
+#' @noRd
+parse_java_major_version <- function(java_ver_str) {
+  if (is.null(java_ver_str) || !nzchar(java_ver_str)) {
+    return(NULL)
+  }
+
+  matches <- regexec("^(1\\.)?([0-9]+)", java_ver_str)
+  parts <- regmatches(java_ver_str, matches)[[1]]
+
+  if (length(parts) < 3) {
+    return(NULL)
+  }
+
+  parts[3]
 }
 
 #' Find path to libjvm dynamic library
@@ -394,22 +438,7 @@ java_check_current_rjava_version <- function() {
     return(NULL)
   }
 
-  # Parse version: "1.8.0_..." -> "8", "17.0.1" -> "17"
-  matches <- regexec(
-    "^(1\\.)?([0-9]+)",
-    java_ver_str
-  )
-  parts <- regmatches(java_ver_str, matches)[[1]]
-
-  if (length(parts) < 3) {
-    return(NULL)
-  }
-
-  major <- parts[3]
-  # Handle 1.8 -> 8 case (parts[2] is "1." and parts[3] is "8")
-  # Handle 17 -> 17 case (parts[2] is "" and parts[3] is "17")
-
-  return(major)
+  parse_java_major_version(java_ver_str)
 }
 
 #' Find the actual extracted directory, ignoring hidden/metadata files

--- a/R/internal_utilities.R
+++ b/R/internal_utilities.R
@@ -86,8 +86,15 @@ java_subprocess_env <- function(java_home, rjava = FALSE) {
   checkmate::assert_logical(rjava, len = 1)
 
   env_vars <- Sys.getenv()
+  env_get <- function(name) {
+    if (name %in% names(env_vars)) {
+      env_vars[[name]]
+    } else {
+      NA_character_
+    }
+  }
   java_bin <- file.path(java_home, "bin")
-  old_path <- env_vars[["PATH"]]
+  old_path <- env_get("PATH")
 
   env_vars["JAVA_HOME"] <- java_home
   env_vars["PATH"] <- paste(java_bin, old_path, sep = .Platform$path.sep)
@@ -105,7 +112,7 @@ java_subprocess_env <- function(java_home, rjava = FALSE) {
   jvm_lib_dir <- dirname(libjvm_path)
 
   if (identical(sysname, "Linux")) {
-    old_ld <- env_vars[["LD_LIBRARY_PATH"]]
+    old_ld <- env_get("LD_LIBRARY_PATH")
     if (is.na(old_ld)) {
       old_ld <- ""
     }
@@ -116,7 +123,7 @@ java_subprocess_env <- function(java_home, rjava = FALSE) {
       jvm_lib_dir
     }
   } else if (identical(sysname, "Darwin")) {
-    old_dyld <- env_vars[["DYLD_LIBRARY_PATH"]]
+    old_dyld <- env_get("DYLD_LIBRARY_PATH")
     if (is.na(old_dyld)) {
       old_dyld <- ""
     }

--- a/R/java_env.R
+++ b/R/java_env.R
@@ -305,21 +305,39 @@ java_check_version_rjava <- function(
 
 # Original implementation (not memoised) - used when .use_cache = FALSE
 ._java_version_check_rjava_impl_original <- function(java_home = NULL) {
-  # Get the code of the unexported function to use in a script
-  internal_function <- getFromNamespace(
+  # Get the code of the unexported functions to use in a script
+  # On Linux, the script depends on get_libjvm_path() to avoid crashes in .jinit()
+  java_version_check_fn <- getFromNamespace(
     "java_version_check_rscript",
     "rJavaEnv"
   )
-  script_content <- paste(deparse(body(internal_function)), collapse = "\n")
+  get_libjvm_path_fn <- getFromNamespace("get_libjvm_path", "rJavaEnv")
 
-  # Create a wrapper script that includes the function definition and calls it
+  java_version_check_body <- paste(
+    deparse(body(java_version_check_fn)),
+    collapse = "\n"
+  )
+  get_libjvm_path_body <- paste(
+    deparse(body(get_libjvm_path_fn)),
+    collapse = "\n"
+  )
+
+  # Create a wrapper script that includes the function definitions and calls them
   # Capture current libPaths to ensure subprocess can find rJava in renv/packrat environments
   libs_code <- paste0(".libPaths(", deparse(as.character(.libPaths())), ")")
 
-  wrapper_script <- sprintf(
-    "%s\njava_version_check <- function(java_home) {\n%s\n}\n\nargs <- commandArgs(trailingOnly = TRUE)\nresult <- java_version_check(args[1])\ncat(result, sep = '\n')",
+  wrapper_script <- paste0(
     libs_code,
-    script_content
+    "\n\n",
+    "get_libjvm_path <- function(java_home) {\n",
+    get_libjvm_path_body,
+    "\n}\n\n",
+    "java_version_check <- function(java_home) {\n",
+    java_version_check_body,
+    "\n}\n\n",
+    "args <- commandArgs(trailingOnly = TRUE)\n",
+    "result <- java_version_check(args[1])\n",
+    "cat(result, sep = '\n')"
   )
 
   # Write the wrapper script to a temporary file

--- a/R/java_env.R
+++ b/R/java_env.R
@@ -305,32 +305,70 @@ java_check_version_rjava <- function(
 
 # Original implementation (not memoised) - used when .use_cache = FALSE
 ._java_version_check_rjava_impl_original <- function(java_home = NULL) {
-  # Get the code of the unexported functions to use in a script
-  # On Linux, the script depends on get_libjvm_path() to avoid crashes in .jinit()
+  if (is.null(java_home) || !nzchar(java_home)) {
+    return(FALSE)
+  }
+
+  if (requireNamespace("callr", quietly = TRUE)) {
+    data <- tryCatch(
+      {
+        callr::r(
+          func = function() {
+            suppressWarnings(rJava::.jinit())
+            java_version <- suppressWarnings(
+              rJava::.jcall(
+                "java.lang.System",
+                "S",
+                "getProperty",
+                "java.version"
+              )
+            )
+
+            list(
+              java_version = java_version,
+              output = cli::format_message(
+                paste0(
+                  "rJava and other rJava/Java-based packages will use ",
+                  "Java version: {.val {java_version}}"
+                )
+              )
+            )
+          },
+          libpath = .libPaths(),
+          env = java_subprocess_env(java_home, rjava = TRUE),
+          show = FALSE
+        )
+      },
+      error = function(e) FALSE
+    )
+
+    if (!isFALSE(data)) {
+      major_java_ver <- parse_java_major_version(data$java_version)
+      if (!is.null(major_java_ver)) {
+        return(list(
+          major_version = major_java_ver,
+          output = data$output
+        ))
+      }
+    }
+  }
+
   java_version_check_fn <- getFromNamespace(
     "java_version_check_rscript",
     "rJavaEnv"
   )
-  get_libjvm_path_fn <- getFromNamespace("get_libjvm_path", "rJavaEnv")
 
-  # Helper to deparse and collapse multi-line expressions
   deparse_collapse <- function(x) {
     paste(deparse(x, width.cutoff = 500), collapse = "\n")
   }
 
   java_version_check_body <- deparse_collapse(body(java_version_check_fn))
-  get_libjvm_path_body <- deparse_collapse(body(get_libjvm_path_fn))
   libs_val <- deparse_collapse(as.character(.libPaths()))
 
-  # Create a wrapper script that includes the function definitions and calls them
-  # Capture current libPaths to ensure subprocess can find rJava in renv/packrat environments
   wrapper_script <- paste0(
     ".libPaths(",
     libs_val,
     ")\n\n",
-    "get_libjvm_path <- function(java_home) ",
-    get_libjvm_path_body,
-    "\n\n",
     "java_version_check <- function(java_home) ",
     java_version_check_body,
     "\n\n",
@@ -341,46 +379,42 @@ java_check_version_rjava <- function(
     "}"
   )
 
-  # Write the wrapper script to a temporary file
   script_file <- tempfile(fileext = ".R")
   writeLines(wrapper_script, script_file)
 
-  # Run the script in a separate R session and capture the output
-  rscript_path <- file.path(R.home("bin"), "Rscript")
-  output <- suppressWarnings(system2(
-    rscript_path,
-    args = c(script_file, java_home),
-    stdout = TRUE,
-    stderr = TRUE,
-    timeout = 5
-  ))
+  output <- tryCatch(
+    suppressWarnings(system2(
+      file.path(R.home("bin"), "Rscript"),
+      args = c(script_file, java_home),
+      stdout = TRUE,
+      stderr = TRUE,
+      timeout = 5,
+      env = java_subprocess_env(java_home, rjava = TRUE)
+    )),
+    error = function(e) character(0)
+  )
 
-  # Delete the temporary script file
   unlink(script_file)
 
-  # Process the output (no printing here)
   if (length(output) == 0 || any(grepl("error", tolower(output)))) {
     return(FALSE)
   }
 
   output <- paste(output, collapse = "\n")
   cleaned_output <- cli::ansi_strip(output)
-  major_java_ver <- sub('.*version: \\"([0-9]+).*', '\\1', cleaned_output)
+  version_matches <- regexec('version: \\"([^\\"]+)\\"', cleaned_output)
+  version_parts <- regmatches(cleaned_output, version_matches)[[1]]
+  java_version <- if (length(version_parts) > 1) version_parts[2] else NULL
+  major_java_ver <- parse_java_major_version(java_version)
 
-  if (!nzchar(major_java_ver) || !grepl("^[0-9]+$", major_java_ver)) {
+  if (is.null(major_java_ver)) {
     return(FALSE)
   }
 
-  # Fix 1 to 8, as Java 8 prints "1.8"
-  if (major_java_ver == "1") {
-    major_java_ver <- "8"
-  }
-
-  # Return structured data for printing in wrapper
-  return(list(
+  list(
     major_version = major_java_ver,
     output = output
-  ))
+  )
 }
 
 # Internal function: Spawn subprocess to check Java with rJava - this gets cached

--- a/R/java_list_available.R
+++ b/R/java_list_available.R
@@ -103,62 +103,16 @@ java_list_available <- function(
 
 #' @keywords internal
 list_temurin_versions_impl <- function(platform, arch) {
-  # Adoptium API mapping
-  api_os <- switch(
-    platform,
-    "macos" = "mac",
-    "alpine-linux" = "alpine-linux",
-    platform
+  candidates <- tryCatch(
+    java_valid_major_versions_temurin(platform = platform, arch = arch),
+    error = function(e) character(0)
   )
 
-  # We first get available major releases
-  major_vers <- tryCatch(
-    java_valid_major_versions_temurin(),
-    error = function(e) return(NULL)
-  )
-
-  if (is.null(major_vers)) {
+  if (length(candidates) == 0) {
     return(data.frame())
   }
 
-  all_releases <- list()
-
-  for (v in major_vers) {
-    url <- sprintf(
-      "https://api.adoptium.net/v3/assets/feature_releases/%s/ga?os=%s&architecture=%s&image_type=jdk&jvm_impl=hotspot",
-      v,
-      api_os,
-      arch
-    )
-
-    data <- tryCatch(
-      read_json_url(url, max_simplify_lvl = "list"),
-      error = function(e) NULL
-    )
-
-    if (is.null(data) || length(data) == 0) {
-      next
-    }
-
-    for (rel in data) {
-      all_releases[[length(all_releases) + 1]] <- data.frame(
-        backend = "native",
-        vendor = "Temurin",
-        major = as.integer(v),
-        version = rel$version_data$semver,
-        platform = platform,
-        arch = arch,
-        identifier = rel$version_data$openjdk_version,
-        checksum_available = TRUE,
-        stringsAsFactors = FALSE
-      )
-    }
-  }
-
-  if (length(all_releases) == 0) {
-    return(data.frame())
-  }
-  do.call(rbind, all_releases)
+  temurin_probe_available_versions(platform, arch, candidates)$releases
 }
 
 #' @keywords internal

--- a/R/java_scoped.R
+++ b/R/java_scoped.R
@@ -177,32 +177,7 @@ with_rjava_env <- function(
   )
 
   # 2. Define the environment variables for the subprocess
-  env_vars <- Sys.getenv() # Copy current env
-
-  # Update JAVA variables
-  env_vars["JAVA_HOME"] = java_home
-
-  # Prepend to PATH
-  java_bin <- file.path(java_home, "bin")
-  old_path <- env_vars["PATH"]
-  env_vars["PATH"] = paste(java_bin, old_path, sep = .Platform$path.sep)
-
-  # Linux specific: LD_LIBRARY_PATH for rJava
-  if (Sys.info()["sysname"] == "Linux") {
-    libjvm_path <- get_libjvm_path(java_home)
-    if (!is.null(libjvm_path)) {
-      jvm_lib_dir <- dirname(libjvm_path)
-      old_ld <- env_vars["LD_LIBRARY_PATH"]
-      if (is.na(old_ld)) {
-        old_ld <- ""
-      }
-      env_vars["LD_LIBRARY_PATH"] = paste(
-        jvm_lib_dir,
-        old_ld,
-        sep = .Platform$path.sep
-      )
-    }
-  }
+  env_vars <- java_subprocess_env(java_home, rjava = TRUE)
 
   # 3. Run in subprocess
   callr::r(

--- a/R/java_valid_versions.R
+++ b/R/java_valid_versions.R
@@ -55,6 +55,93 @@ java_valid_versions_fast <- function() {
   return(fallback)
 }
 
+#' @keywords internal
+#' @noRd
+temurin_candidate_versions <- function(platform, arch) {
+  fallback_cfg <- java_config("fallback_versions")$Temurin
+  platform_key <- paste(platform, arch, sep = "_")
+
+  candidates <- fallback_cfg[[platform_key]] %||% fallback_cfg$default
+  as.character(candidates)
+}
+
+#' @keywords internal
+#' @noRd
+temurin_probe_available_versions <- function(platform, arch, candidates) {
+  api_os <- switch(
+    platform,
+    "macos" = "mac",
+    "alpine-linux" = "alpine-linux",
+    platform
+  )
+
+  candidates <- unique(as.character(candidates))
+  all_releases <- list()
+  successful_requests <- 0L
+
+  for (v in candidates) {
+    url <- sprintf(
+      paste0(
+        "https://api.adoptium.net/v3/assets/latest/%s/hotspot?",
+        "os=%s&architecture=%s&image_type=jdk"
+      ),
+      v,
+      api_os,
+      arch
+    )
+
+    data <- tryCatch(
+      read_json_url(url, max_simplify_lvl = "list"),
+      error = function(e) NULL
+    )
+
+    if (is.null(data)) {
+      next
+    }
+
+    successful_requests <- successful_requests + 1L
+
+    if (length(data) == 0) {
+      next
+    }
+
+    for (rel in data) {
+      if (is.null(rel$binary$package$link)) {
+        next
+      }
+
+      all_releases[[length(all_releases) + 1L]] <- data.frame(
+        backend = "native",
+        vendor = "Temurin",
+        major = as.integer(v),
+        version = rel$version_data$semver %||% rel$release_name %||% v,
+        platform = platform,
+        arch = arch,
+        identifier = rel$version_data$openjdk_version %||% rel$release_name %||% v,
+        checksum_available = !is.null(rel$binary$package$checksum),
+        stringsAsFactors = FALSE
+      )
+    }
+  }
+
+  releases <- if (length(all_releases) > 0) {
+    do.call(rbind, all_releases)
+  } else {
+    data.frame()
+  }
+
+  list(
+    releases = releases,
+    majors = if (nrow(releases) > 0) {
+      as.character(sort(unique(releases$major)))
+    } else {
+      character(0)
+    },
+    successful_requests = successful_requests,
+    attempted_candidates = candidates
+  )
+}
+
 #' Retrieve Valid Java Versions
 #'
 #' This function retrieves a list of valid Java versions by querying an appropriate API endpoint based on the chosen distribution.
@@ -266,11 +353,70 @@ java_valid_major_versions_corretto <- function(
 #'
 #' @keywords internal
 java_valid_major_versions_temurin <- function(arch = NULL, platform = NULL) {
-  # Note: The 'available_releases' endpoint lists *all* versions, regardless of platform/arch.
-  # This serves as a quick check for valid version numbers.
-  url <- "https://api.adoptium.net/v3/info/available_releases"
-  response <- read_json_url(url)
-  as.character(response$available_releases)
+  if (is.null(platform) || is.null(arch)) {
+    plat <- platform_detect(quiet = TRUE)
+    if (is.null(platform)) {
+      platform <- plat$os
+    }
+    if (is.null(arch)) {
+      arch <- plat$arch
+    }
+  }
+
+  fallback_candidates <- temurin_candidate_versions(platform, arch)
+
+  summary_versions <- tryCatch(
+    {
+      response <- read_json_url("https://api.adoptium.net/v3/info/available_releases")
+      versions <- as.character(response$available_releases)
+      versions <- versions[
+        nzchar(versions) & grepl("^[0-9]+$", versions)
+      ]
+      if (length(versions) == 0) {
+        cli::cli_inform(
+          paste0(
+            "Temurin summary endpoint returned no usable major versions. ",
+            "Falling back to asset-backed version discovery."
+          )
+        )
+        NULL
+      } else {
+        versions
+      }
+    },
+    error = function(e) {
+      cli::cli_inform(
+        paste0(
+          "Temurin summary endpoint could not be read (",
+          e$message,
+          "). Falling back to asset-backed version discovery."
+        )
+      )
+      NULL
+    }
+  )
+
+  candidates <- summary_versions %||% fallback_candidates
+  probe <- temurin_probe_available_versions(platform, arch, candidates)
+
+  if (probe$successful_requests == 0) {
+    cli::cli_warn(
+      paste0(
+        "Temurin asset probes failed for all candidate versions on ",
+        platform,
+        "/",
+        arch,
+        ". Returning shipped fallback versions."
+      )
+    )
+    return(fallback_candidates)
+  }
+
+  if (length(probe$majors) == 0) {
+    return(character(0))
+  }
+
+  probe$majors
 }
 
 #' Get Available Online Versions of Azul Zulu

--- a/tests/testthat/test-backend_propagates.R
+++ b/tests/testthat/test-backend_propagates.R
@@ -1,4 +1,6 @@
 test_that("backend argument propagates in use_java", {
+  state <- new.env(parent = emptyenv())
+  state$download_called_backend <- NULL
   local_mocked_bindings(
     java_list_installed = function(...) {
       data.frame(
@@ -17,10 +19,9 @@ test_that("backend argument propagates in use_java", {
   )
 
   # Should NOT find in cache because we ask for "native" (default) but cache has "sdkman"
-  download_called_backend <- NULL
   local_mocked_bindings(
     java_download = function(..., backend) {
-      download_called_backend <<- backend
+      state$download_called_backend <- backend
       return("mock_dist_path")
     },
     java_unpack = function(...) "mock_unpack_path",
@@ -34,20 +35,22 @@ test_that("backend argument propagates in use_java", {
     backend = "native",
     quiet = TRUE
   )
-  expect_equal(download_called_backend, "native")
+  expect_equal(state$download_called_backend, "native")
 
   # Should FIND in cache because backend matches
-  download_called_backend <- NULL
+  state$download_called_backend <- NULL
   use_java(
     version = 21,
     distribution = "Corretto",
     backend = "sdkman",
     quiet = TRUE
   )
-  expect_null(download_called_backend)
+  expect_null(state$download_called_backend)
 })
 
 test_that("backend argument propagates in java_resolve", {
+  state <- new.env(parent = emptyenv())
+  state$download_called_backend <- NULL
   local_mocked_bindings(
     java_list_installed = function(...) {
       data.frame(
@@ -67,10 +70,9 @@ test_that("backend argument propagates in java_resolve", {
   )
 
   # Should NOT find in cache
-  download_called_backend <- NULL
   local_mocked_bindings(
     java_download = function(..., backend) {
-      download_called_backend <<- backend
+      state$download_called_backend <- backend
       return("mock_dist_path")
     },
     java_unpack = function(...) "mock_unpack_path",
@@ -85,25 +87,26 @@ test_that("backend argument propagates in java_resolve", {
     backend = "native",
     quiet = TRUE
   )
-  expect_equal(download_called_backend, "native")
+  expect_equal(state$download_called_backend, "native")
 
   # Should FIND in cache
-  download_called_backend <- NULL
+  state$download_called_backend <- NULL
   res <- java_resolve(
     version = 21,
     distribution = "Corretto",
     backend = "sdkman",
     quiet = TRUE
   )
-  expect_null(download_called_backend)
+  expect_null(state$download_called_backend)
   expect_equal(res, "path/to/java")
 })
 
 test_that("backend argument propagates in java_quick_install", {
-  download_called_backend <- NULL
+  state <- new.env(parent = emptyenv())
+  state$download_called_backend <- NULL
   local_mocked_bindings(
     java_download = function(..., backend) {
-      download_called_backend <<- backend
+      state$download_called_backend <- backend
       return("mock_dist_path")
     },
     java_install = function(...) "mock_home",
@@ -119,7 +122,7 @@ test_that("backend argument propagates in java_quick_install", {
     quiet = TRUE,
     temp_dir = TRUE
   )
-  expect_equal(download_called_backend, "sdkman")
+  expect_equal(state$download_called_backend, "sdkman")
 })
 
 test_that("backend argument propagates in java_ensure", {

--- a/tests/testthat/test-internal_utilities_extra.R
+++ b/tests/testthat/test-internal_utilities_extra.R
@@ -45,13 +45,14 @@ test_that("java_version_check_rscript function exists", {
 test_that("rje_readline passes prompt to base::readline", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
+  state <- new.env(parent = emptyenv())
+  state$captured_prompt <- NULL
 
   # This test verifies the wrapper exists and is mockable
   # We mock base::readline to capture the call
-  captured_prompt <- NULL
   local_mocked_bindings(
     readline = function(prompt = "") {
-      captured_prompt <<- prompt
+      state$captured_prompt <- prompt
       "mocked_response"
     },
     .package = "base"
@@ -59,6 +60,6 @@ test_that("rje_readline passes prompt to base::readline", {
 
   result <- rJavaEnv:::rje_readline(prompt = "Enter value: ")
 
-  expect_equal(captured_prompt, "Enter value: ")
+  expect_equal(state$captured_prompt, "Enter value: ")
   expect_equal(result, "mocked_response")
 })

--- a/tests/testthat/test-internal_utilities_rjava.R
+++ b/tests/testthat/test-internal_utilities_rjava.R
@@ -72,7 +72,7 @@ test_that("java_check_current_rjava_version returns NULL on rJava error", {
   expect_null(result)
 })
 
-test_that("java_version_check_rscript sets JAVA_HOME correctly", {
+test_that("java_version_check_rscript returns formatted version output", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
   skip_on_os("windows") # Different behavior
@@ -87,12 +87,6 @@ test_that("java_version_check_rscript sets JAVA_HOME correctly", {
     `.jinit` = function(...) 0,
     `.jcall` = function(...) "21.0.1",
     .package = "rJava"
-  )
-
-  # Mock get_libjvm_path to return NULL (no libjvm needed)
-  local_mocked_bindings(
-    get_libjvm_path = function(...) NULL,
-    .package = "rJavaEnv"
   )
 
   result <- rJavaEnv:::java_version_check_rscript(java_home)

--- a/tests/testthat/test-internal_utilities_rjava.R
+++ b/tests/testthat/test-internal_utilities_rjava.R
@@ -107,3 +107,11 @@ test_that("java_version_check_rscript handles errors gracefully", {
 
   expect_true(grepl("Error", result))
 })
+
+test_that("parse_java_major_version handles valid and invalid inputs", {
+  expect_equal(rJavaEnv:::parse_java_major_version("21.0.8"), "21")
+  expect_equal(rJavaEnv:::parse_java_major_version("1.8.0_452"), "8")
+  expect_null(rJavaEnv:::parse_java_major_version(NULL))
+  expect_null(rJavaEnv:::parse_java_major_version(""))
+  expect_null(rJavaEnv:::parse_java_major_version("not-a-version"))
+})

--- a/tests/testthat/test-java_build_env.R
+++ b/tests/testthat/test-java_build_env.R
@@ -38,6 +38,8 @@ test_that("java_build_env_set writes to .Rprofile in project", {
 })
 
 test_that("java_build_env_set writes to .Rprofile with 'both' option", {
+  state <- new.env(parent = emptyenv())
+  state$set_env_called <- FALSE
   proj_dir <- withr::local_tempdir()
   local_mocked_bindings(
     rje_consent_check = function() TRUE,
@@ -45,10 +47,9 @@ test_that("java_build_env_set writes to .Rprofile with 'both' option", {
   )
 
   # Mock set_java_build_env_vars to avoid side effects
-  set_env_called <- FALSE
   local_mocked_bindings(
     set_java_build_env_vars = function(...) {
-      set_env_called <<- TRUE
+      state$set_env_called <- TRUE
       invisible(NULL)
     },
     .package = "rJavaEnv"
@@ -62,7 +63,7 @@ test_that("java_build_env_set writes to .Rprofile with 'both' option", {
   )
 
   # Check both session and project were affected
-  expect_true(set_env_called)
+  expect_true(state$set_env_called)
   rprof <- file.path(proj_dir, ".Rprofile")
   expect_true(file.exists(rprof))
 })

--- a/tests/testthat/test-java_check_unit.R
+++ b/tests/testthat/test-java_check_unit.R
@@ -68,12 +68,13 @@ test_that("java_check_compatibility fails when current < required with type=min"
 
 # Test when rJava not loaded but requireNamespace succeeds
 test_that("java_check_compatibility tries jinit when rJava available", {
-  jinit_called <- FALSE
+  state <- new.env(parent = emptyenv())
+  state$jinit_called <- FALSE
 
   local_mocked_bindings(
     java_check_current_rjava_version = function() {
       # First call returns NULL, second returns version
-      if (jinit_called) "21" else NULL
+      if (state$jinit_called) "21" else NULL
     },
     .package = "rJavaEnv"
   )
@@ -92,7 +93,7 @@ test_that("java_check_compatibility tries jinit when rJava available", {
   # Mock rJava::.jinit
   local_mocked_bindings(
     .jinit = function(...) {
-      jinit_called <<- TRUE
+      state$jinit_called <- TRUE
       invisible(NULL)
     },
     .package = "rJava"

--- a/tests/testthat/test-java_download-mocked.R
+++ b/tests/testthat/test-java_download-mocked.R
@@ -145,6 +145,8 @@ test_that("java_download skips download if file exists and force is FALSE", {
 
 
 test_that("java_download overwrites if file exists and force is TRUE", {
+  state <- new.env(parent = emptyenv())
+  state$curl_call_count <- 0
   local_cache_path <- withr::local_tempdir()
   dest_dir <- file.path(local_cache_path, "distrib")
   dir.create(dest_dir, recursive = TRUE)
@@ -173,10 +175,9 @@ test_that("java_download overwrites if file exists and force is TRUE", {
     }
   )
 
-  curl_call_count <- 0
   local_mocked_bindings(
     curl_download = function(url, destfile, ...) {
-      curl_call_count <<- curl_call_count + 1
+      state$curl_call_count <- state$curl_call_count + 1
       writeLines("new content", destfile)
     },
     .package = "curl"
@@ -196,6 +197,6 @@ test_that("java_download overwrites if file exists and force is TRUE", {
     force = TRUE
   )
 
-  expect_equal(curl_call_count, 1)
+  expect_equal(state$curl_call_count, 1)
   expect_equal(readLines(expected_file_path), "new content")
 })

--- a/tests/testthat/test-java_env_extended.R
+++ b/tests/testthat/test-java_env_extended.R
@@ -30,6 +30,8 @@ test_that("java_env_set project mode creates .Rprofile", {
 
 # Test java_env_set with both mode
 test_that("java_env_set both mode sets session and writes .Rprofile", {
+  state <- new.env(parent = emptyenv())
+  state$session_set <- FALSE
   proj_dir <- withr::local_tempdir()
 
   local_mocked_bindings(
@@ -37,10 +39,9 @@ test_that("java_env_set both mode sets session and writes .Rprofile", {
     .package = "rJavaEnv"
   )
 
-  session_set <- FALSE
   local_mocked_bindings(
     java_env_set_session = function(...) {
-      session_set <<- TRUE
+      state$session_set <- TRUE
       invisible(NULL)
     },
     .package = "rJavaEnv"
@@ -53,7 +54,7 @@ test_that("java_env_set both mode sets session and writes .Rprofile", {
     quiet = TRUE
   )
 
-  expect_true(session_set)
+  expect_true(state$session_set)
   expect_true(file.exists(file.path(proj_dir, ".Rprofile")))
 })
 

--- a/tests/testthat/test-java_env_subprocess_regression.R
+++ b/tests/testthat/test-java_env_subprocess_regression.R
@@ -1,0 +1,73 @@
+#' Test that java_check_version_rjava() correctly constructs the subprocess script
+#' without duplication issues when .libPaths() contains multiple paths.
+
+test_that("._java_version_check_rjava_impl_original handles multi-line .libPaths correctly", {
+  # Mock a scenario where .libPaths() has multiple long paths
+  # This previously caused duplication in paste0() because deparse() returned a vector.
+  mock_paths <- c(
+    "/usr/lib/R/library",
+    "/usr/local/lib/R/site-library",
+    "/home/user/R/x86_64-pc-linux-gnu-library/4.5"
+  )
+
+  captured_script <- NULL
+
+  # Mock get_libjvm_path to return a simple known string
+  local_mocked_bindings(
+    get_libjvm_path = function(...) "/mock/libjvm.so",
+    .package = "rJavaEnv"
+  )
+
+  local_mocked_bindings(
+    .libPaths = function(...) mock_paths,
+    system2 = function(command, args, ...) {
+      # The first argument in args is the script file path
+      if (file.exists(args[1])) {
+        captured_script <<- readLines(args[1])
+      }
+      # Return valid dummy output
+      return(c(
+        "rJava and other rJava/Java-based packages will use Java version: \"21\""
+      ))
+    },
+    .package = "base"
+  )
+
+  # Call the internal function
+  result <- rJavaEnv:::._java_version_check_rjava_impl_original(
+    java_home = "/mock/java"
+  )
+
+  # Assertions on the captured script
+  # Avoid expect_* functions that might trigger 'waldo' dependency issues.
+  # Using simple R logic that throws an error on failure, which testthat will catch.
+  if (is.null(captured_script)) {
+    stop("Captured script is NULL")
+  }
+
+  # 1. Check for duplication of function definitions
+  def_count <- sum(grepl("java_version_check <- function", captured_script))
+  if (!identical(as.numeric(def_count), 1)) {
+    stop(sprintf(
+      "The function definition should appear exactly once, but found %d",
+      def_count
+    ))
+  }
+
+  # 2. Check that .libPaths() contains all paths in a valid call
+  script_text <- paste(captured_script, collapse = "\n")
+  if (!grepl("\\.libPaths\\(c\\(", script_text)) {
+    stop("Should use c() for multiple library paths.")
+  }
+  if (!grepl("/home/user/R/x86_64-pc-linux-gnu-library/4.5", script_text)) {
+    stop("Last path should be present.")
+  }
+
+  # 3. Check for syntax errors (no stray commas at line ends from bad paste)
+  if (grepl(", \\)", script_text)) {
+    stop("Malformed closing parenthesis found.")
+  }
+
+  # Final verification: if we reached here, the test passed.
+  expect_silent(NULL)
+})

--- a/tests/testthat/test-java_env_subprocess_regression.R
+++ b/tests/testthat/test-java_env_subprocess_regression.R
@@ -35,6 +35,86 @@ test_that("._java_version_check_rjava_impl_original prefers callr", {
   expect_equal(state$captured_libpath, .libPaths())
 })
 
+test_that("._java_version_check_rjava_impl_original returns FALSE without java_home", {
+  expect_false(rJavaEnv:::._java_version_check_rjava_impl_original(NULL))
+  expect_false(rJavaEnv:::._java_version_check_rjava_impl_original(""))
+})
+
+test_that("._java_version_check_rjava_impl_original falls back when callr errors", {
+  skip_if_not_installed("callr")
+  state <- new.env(parent = emptyenv())
+  state$captured_env <- NULL
+
+  local_mocked_bindings(
+    r = function(...) stop("callr failed"),
+    .package = "callr"
+  )
+
+  local_mocked_bindings(
+    java_subprocess_env = function(java_home, rjava = FALSE) {
+      state$captured_env <- c(
+        JAVA_HOME = java_home,
+        PATH = paste0(java_home, "/bin")
+      )
+      state$captured_env
+    },
+    .package = "rJavaEnv"
+  )
+
+  local_mocked_bindings(
+    system2 = function(command, args, stdout, stderr, timeout, env) {
+      state$captured_env <- env
+      c(
+        "rJava and other rJava/Java-based packages will use Java version: \"17.0.9\""
+      )
+    },
+    .package = "base"
+  )
+
+  result <- rJavaEnv:::._java_version_check_rjava_impl_original(
+    java_home = "/mock/java"
+  )
+
+  expect_equal(result$major_version, "17")
+  expect_equal(state$captured_env[["JAVA_HOME"]], "/mock/java")
+})
+
+test_that("._java_version_check_rjava_impl_original falls back when callr output is unusable", {
+  skip_if_not_installed("callr")
+
+  local_mocked_bindings(
+    r = function(...) {
+      list(
+        java_version = "not-a-version",
+        output = "rJava and other rJava/Java-based packages will use Java version: \"not-a-version\""
+      )
+    },
+    .package = "callr"
+  )
+
+  local_mocked_bindings(
+    java_subprocess_env = function(java_home, rjava = FALSE) {
+      c(JAVA_HOME = java_home, PATH = paste0(java_home, "/bin"))
+    },
+    .package = "rJavaEnv"
+  )
+
+  local_mocked_bindings(
+    system2 = function(...) {
+      c(
+        "rJava and other rJava/Java-based packages will use Java version: \"25.0.2\""
+      )
+    },
+    .package = "base"
+  )
+
+  result <- rJavaEnv:::._java_version_check_rjava_impl_original(
+    java_home = "/mock/java"
+  )
+
+  expect_equal(result$major_version, "25")
+})
+
 test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
   mock_paths <- c(
     "/usr/lib/R/library",
@@ -91,4 +171,50 @@ test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
   expect_true(grepl("\\.libPaths\\(c\\(", script_text))
   expect_true(grepl("/home/user/R/x86_64-pc-linux-gnu-library/4.5", script_text))
   expect_false(any(grepl("get_libjvm_path <- function", state$captured_script)))
+})
+
+test_that("._java_version_check_rjava_impl_original returns FALSE on bad subprocess output", {
+  local_mocked_bindings(
+    requireNamespace = function(pkg, quietly = TRUE) FALSE,
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    java_subprocess_env = function(java_home, rjava = FALSE) {
+      c(JAVA_HOME = java_home, PATH = paste0(java_home, "/bin"))
+    },
+    .package = "rJavaEnv"
+  )
+
+  local_mocked_bindings(
+    system2 = function(...) character(0),
+    .package = "base"
+  )
+
+  expect_false(
+    rJavaEnv:::._java_version_check_rjava_impl_original(java_home = "/mock/java")
+  )
+})
+
+test_that("._java_version_check_rjava_impl_original returns FALSE on subprocess error text", {
+  local_mocked_bindings(
+    requireNamespace = function(pkg, quietly = TRUE) FALSE,
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    java_subprocess_env = function(java_home, rjava = FALSE) {
+      c(JAVA_HOME = java_home, PATH = paste0(java_home, "/bin"))
+    },
+    .package = "rJavaEnv"
+  )
+
+  local_mocked_bindings(
+    system2 = function(...) "Error checking Java version: JVM init failed",
+    .package = "base"
+  )
+
+  expect_false(
+    rJavaEnv:::._java_version_check_rjava_impl_original(java_home = "/mock/java")
+  )
 })

--- a/tests/testthat/test-java_env_subprocess_regression.R
+++ b/tests/testthat/test-java_env_subprocess_regression.R
@@ -1,9 +1,38 @@
-#' Test that java_check_version_rjava() correctly constructs the subprocess script
-#' without duplication issues when .libPaths() contains multiple paths.
+test_that("._java_version_check_rjava_impl_original prefers callr", {
+  skip_if_not_installed("callr")
 
-test_that("._java_version_check_rjava_impl_original handles multi-line .libPaths correctly", {
-  # Mock a scenario where .libPaths() has multiple long paths
-  # This previously caused duplication in paste0() because deparse() returned a vector.
+  captured_env <- NULL
+  captured_libpath <- NULL
+
+  local_mocked_bindings(
+    r = function(func, args = list(), libpath, env, show) {
+      captured_env <<- env
+      captured_libpath <<- libpath
+      list(
+        java_version = "21.0.8",
+        output = "rJava and other rJava/Java-based packages will use Java version: \"21.0.8\""
+      )
+    },
+    .package = "callr"
+  )
+
+  local_mocked_bindings(
+    java_subprocess_env = function(java_home, rjava = FALSE) {
+      c(JAVA_HOME = java_home, PATH = paste(java_home, "bin", sep = "/"))
+    },
+    .package = "rJavaEnv"
+  )
+
+  result <- rJavaEnv:::._java_version_check_rjava_impl_original(
+    java_home = "/mock/java"
+  )
+
+  expect_equal(result$major_version, "21")
+  expect_equal(captured_env[["JAVA_HOME"]], "/mock/java")
+  expect_equal(captured_libpath, .libPaths())
+})
+
+test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
   mock_paths <- c(
     "/usr/lib/R/library",
     "/usr/local/lib/R/site-library",
@@ -11,63 +40,43 @@ test_that("._java_version_check_rjava_impl_original handles multi-line .libPaths
   )
 
   captured_script <- NULL
+  captured_env <- NULL
 
-  # Mock get_libjvm_path to return a simple known string
   local_mocked_bindings(
-    get_libjvm_path = function(...) "/mock/libjvm.so",
+    requireNamespace = function(pkg, quietly = TRUE) FALSE,
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    java_subprocess_env = function(java_home, rjava = FALSE) {
+      captured_env <<- c(JAVA_HOME = java_home, PATH = paste0(java_home, "/bin"))
+      captured_env
+    },
     .package = "rJavaEnv"
   )
 
   local_mocked_bindings(
     .libPaths = function(...) mock_paths,
-    system2 = function(command, args, ...) {
-      # The first argument in args is the script file path
+    system2 = function(command, args, stdout, stderr, timeout, env) {
+      captured_env <<- env
       if (file.exists(args[1])) {
         captured_script <<- readLines(args[1])
       }
-      # Return valid dummy output
-      return(c(
-        "rJava and other rJava/Java-based packages will use Java version: \"21\""
-      ))
+      "rJava and other rJava/Java-based packages will use Java version: \"21.0.8\""
     },
     .package = "base"
   )
 
-  # Call the internal function
   result <- rJavaEnv:::._java_version_check_rjava_impl_original(
     java_home = "/mock/java"
   )
 
-  # Assertions on the captured script
-  # Avoid expect_* functions that might trigger 'waldo' dependency issues.
-  # Using simple R logic that throws an error on failure, which testthat will catch.
-  if (is.null(captured_script)) {
-    stop("Captured script is NULL")
-  }
+  expect_equal(result$major_version, "21")
+  expect_equal(captured_env[["JAVA_HOME"]], "/mock/java")
+  expect_false(any(grepl("get_libjvm_path <- function", captured_script)))
+  expect_equal(sum(grepl("java_version_check <- function", captured_script)), 1)
 
-  # 1. Check for duplication of function definitions
-  def_count <- sum(grepl("java_version_check <- function", captured_script))
-  if (!identical(as.numeric(def_count), 1)) {
-    stop(sprintf(
-      "The function definition should appear exactly once, but found %d",
-      def_count
-    ))
-  }
-
-  # 2. Check that .libPaths() contains all paths in a valid call
   script_text <- paste(captured_script, collapse = "\n")
-  if (!grepl("\\.libPaths\\(c\\(", script_text)) {
-    stop("Should use c() for multiple library paths.")
-  }
-  if (!grepl("/home/user/R/x86_64-pc-linux-gnu-library/4.5", script_text)) {
-    stop("Last path should be present.")
-  }
-
-  # 3. Check for syntax errors (no stray commas at line ends from bad paste)
-  if (grepl(", \\)", script_text)) {
-    stop("Malformed closing parenthesis found.")
-  }
-
-  # Final verification: if we reached here, the test passed.
-  expect_silent(NULL)
+  expect_true(grepl("\\.libPaths\\(c\\(", script_text))
+  expect_true(grepl("/home/user/R/x86_64-pc-linux-gnu-library/4.5", script_text))
 })

--- a/tests/testthat/test-java_env_subprocess_regression.R
+++ b/tests/testthat/test-java_env_subprocess_regression.R
@@ -1,13 +1,13 @@
 test_that("._java_version_check_rjava_impl_original prefers callr", {
   skip_if_not_installed("callr")
-
-  captured_env <- NULL
-  captured_libpath <- NULL
+  state <- new.env(parent = emptyenv())
+  state$captured_env <- NULL
+  state$captured_libpath <- NULL
 
   local_mocked_bindings(
     r = function(func, args = list(), libpath, env, show) {
-      captured_env <<- env
-      captured_libpath <<- libpath
+      state$captured_env <- env
+      state$captured_libpath <- libpath
       list(
         java_version = "21.0.8",
         output = paste0(
@@ -31,8 +31,8 @@ test_that("._java_version_check_rjava_impl_original prefers callr", {
   )
 
   expect_equal(result$major_version, "21")
-  expect_equal(captured_env[["JAVA_HOME"]], "/mock/java")
-  expect_equal(captured_libpath, .libPaths())
+  expect_equal(state$captured_env[["JAVA_HOME"]], "/mock/java")
+  expect_equal(state$captured_libpath, .libPaths())
 })
 
 test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
@@ -42,8 +42,9 @@ test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
     "/home/user/R/x86_64-pc-linux-gnu-library/4.5"
   )
 
-  captured_script <- NULL
-  captured_env <- NULL
+  state <- new.env(parent = emptyenv())
+  state$captured_script <- NULL
+  state$captured_env <- NULL
 
   local_mocked_bindings(
     requireNamespace = function(pkg, quietly = TRUE) FALSE,
@@ -52,8 +53,11 @@ test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
 
   local_mocked_bindings(
     java_subprocess_env = function(java_home, rjava = FALSE) {
-      captured_env <<- c(JAVA_HOME = java_home, PATH = paste0(java_home, "/bin"))
-      captured_env
+      state$captured_env <- c(
+        JAVA_HOME = java_home,
+        PATH = paste0(java_home, "/bin")
+      )
+      state$captured_env
     },
     .package = "rJavaEnv"
   )
@@ -61,9 +65,9 @@ test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
   local_mocked_bindings(
     .libPaths = function(...) mock_paths,
     system2 = function(command, args, stdout, stderr, timeout, env) {
-      captured_env <<- env
+      state$captured_env <- env
       if (file.exists(args[1])) {
-        captured_script <<- readLines(args[1])
+        state$captured_script <- readLines(args[1])
       }
       c(
         "rJava and other rJava/Java-based packages will use Java version: \"21\""
@@ -77,11 +81,14 @@ test_that("._java_version_check_rjava_impl_original falls back to Rscript", {
   )
 
   expect_equal(result$major_version, "21")
-  expect_equal(captured_env[["JAVA_HOME"]], "/mock/java")
-  expect_equal(sum(grepl("java_version_check <- function", captured_script)), 1)
+  expect_equal(state$captured_env[["JAVA_HOME"]], "/mock/java")
+  expect_equal(
+    sum(grepl("java_version_check <- function", state$captured_script)),
+    1
+  )
 
-  script_text <- paste(captured_script, collapse = "\n")
+  script_text <- paste(state$captured_script, collapse = "\n")
   expect_true(grepl("\\.libPaths\\(c\\(", script_text))
   expect_true(grepl("/home/user/R/x86_64-pc-linux-gnu-library/4.5", script_text))
-  expect_false(any(grepl("get_libjvm_path <- function", captured_script)))
+  expect_false(any(grepl("get_libjvm_path <- function", state$captured_script)))
 })

--- a/tests/testthat/test-java_find.R
+++ b/tests/testthat/test-java_find.R
@@ -328,15 +328,15 @@ test_that("java_find_system handles special characters in paths", {
 test_that("java_find_system calls platform_detect", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
+  state <- new.env(parent = emptyenv())
+  state$called <- FALSE
 
   withr::local_envvar(JAVA_HOME = "")
 
   # Mock platform_detect to track if it's called
-  called <- FALSE
-
   local_mocked_bindings(
     platform_detect = function(quiet) {
-      called <<- TRUE
+      state$called <- TRUE
       list(os = "linux", arch = "x64")
     },
     java_check_version_cmd = function(java_home, quiet = TRUE) "17",
@@ -345,21 +345,21 @@ test_that("java_find_system calls platform_detect", {
 
   result <- java_find_system(quiet = TRUE)
 
-  expect_true(called)
+  expect_true(state$called)
   expect_s3_class(result, "data.frame")
 })
 
 test_that("java_find_system passes quiet=TRUE to platform_detect", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
+  state <- new.env(parent = emptyenv())
+  state$quiet_passed <- NULL
 
   withr::local_envvar(JAVA_HOME = "")
 
-  quiet_passed <- NULL
-
   local_mocked_bindings(
     platform_detect = function(quiet) {
-      quiet_passed <<- quiet
+      state$quiet_passed <- quiet
       list(os = "linux", arch = "x64")
     },
     ._java_version_check_impl_original = function(java_home) {
@@ -374,20 +374,20 @@ test_that("java_find_system passes quiet=TRUE to platform_detect", {
   )
 
   java_find_system(quiet = TRUE)
-  expect_true(quiet_passed)
+  expect_true(state$quiet_passed)
 })
 
 test_that("java_find_system passes quiet=FALSE to platform_detect", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
+  state <- new.env(parent = emptyenv())
+  state$quiet_passed <- NULL
 
   withr::local_envvar(JAVA_HOME = "")
 
-  quiet_passed <- NULL
-
   local_mocked_bindings(
     platform_detect = function(quiet) {
-      quiet_passed <<- quiet
+      state$quiet_passed <- quiet
       list(os = "linux", arch = "x64")
     },
     ._java_version_check_impl_original = function(java_home) {
@@ -402,7 +402,7 @@ test_that("java_find_system passes quiet=FALSE to platform_detect", {
   )
 
   java_find_system(quiet = FALSE)
-  expect_false(quiet_passed)
+  expect_false(state$quiet_passed)
 })
 
 test_that("java_find_system handles platform_detect returning different OS values", {
@@ -657,11 +657,12 @@ test_that("is_rjavaenv_cache_path correctly identifies actual cache paths", {
 test_that("._java_find_system_cached returns cached result on second call", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
+  state <- new.env(parent = emptyenv())
+  state$call_count <- 0
 
   # Reset cache for this test
   memoise::forget(rJavaEnv:::._java_find_system_cached)
 
-  call_count <- 0
   mock_scan_result <- data.frame(
     java_home = "/mock/java",
     major_version = "21",
@@ -671,7 +672,7 @@ test_that("._java_find_system_cached returns cached result on second call", {
 
   local_mocked_bindings(
     ._java_find_system_scan_impl = function(...) {
-      call_count <<- call_count + 1
+      state$call_count <- state$call_count + 1
       mock_scan_result
     },
     .package = "rJavaEnv"
@@ -679,11 +680,11 @@ test_that("._java_find_system_cached returns cached result on second call", {
 
   # First call - should call the scan impl
   result1 <- rJavaEnv:::._java_find_system_cached()
-  expect_equal(call_count, 1)
+  expect_equal(state$call_count, 1)
 
   # Second call - should use cache
   result2 <- rJavaEnv:::._java_find_system_cached()
-  expect_equal(call_count, 1) # Still 1, used cache
+  expect_equal(state$call_count, 1) # Still 1, used cache
 
   expect_equal(result1, result2)
 })
@@ -691,11 +692,12 @@ test_that("._java_find_system_cached returns cached result on second call", {
 test_that("java_find_system respects .use_cache = FALSE", {
   skip_on_cran()
   skip_if(!identical(Sys.getenv("CI"), "true"), "Only run on CI")
+  state <- new.env(parent = emptyenv())
+  state$call_count <- 0
 
-  call_count <- 0
   local_mocked_bindings(
     ._java_find_system_scan_impl = function(...) {
-      call_count <<- call_count + 1
+      state$call_count <- state$call_count + 1
       data.frame(
         java_home = "/mock",
         version = "21",
@@ -710,5 +712,5 @@ test_that("java_find_system respects .use_cache = FALSE", {
   java_find_system(.use_cache = FALSE)
   java_find_system(.use_cache = FALSE)
 
-  expect_equal(call_count, 2)
+  expect_equal(state$call_count, 2)
 })

--- a/tests/testthat/test-java_install-mocked.R
+++ b/tests/testthat/test-java_install-mocked.R
@@ -5,6 +5,10 @@
 test_that("java_install succeeds with symlink on Unix-like systems", {
   # This test is for non-Windows behavior
   skip_on_os("windows")
+  state <- new.env(parent = emptyenv())
+  state$env_set_calls <- 0
+  state$symlink_calls <- 0
+  state$symlink_args <- list()
 
   local_proj_path <- withr::local_tempdir(pattern = "project")
   local_cache_path <- withr::local_tempdir(pattern = "cache")
@@ -50,19 +54,16 @@ test_that("java_install succeeds with symlink on Unix-like systems", {
     "21"
   )
 
-  env_set_calls <- 0
   local_mocked_bindings(
     java_env_set = function(...) {
-      env_set_calls <<- env_set_calls + 1
+      state$env_set_calls <- state$env_set_calls + 1
     }
   )
 
-  symlink_calls <- 0
-  symlink_args <- list()
   local_mocked_bindings(
     file.symlink = function(from, to) {
-      symlink_calls <<- symlink_calls + 1
-      symlink_args <<- list(from = from, to = to)
+      state$symlink_calls <- state$symlink_calls + 1
+      state$symlink_args <- list(from = from, to = to)
     },
     .package = "base"
   )
@@ -76,16 +77,18 @@ test_that("java_install succeeds with symlink on Unix-like systems", {
     )
   })
 
-  expect_equal(env_set_calls, 1)
-  expect_equal(symlink_calls, 1)
-  expect_equal(symlink_args$from, fake_unpacked_path)
-  expect_equal(symlink_args$to, expected_symlink_path)
+  expect_equal(state$env_set_calls, 1)
+  expect_equal(state$symlink_calls, 1)
+  expect_equal(state$symlink_args$from, fake_unpacked_path)
+  expect_equal(state$symlink_args$to, expected_symlink_path)
   expect_equal(return_val, fake_unpacked_path)
 })
 
 
 test_that("java_install falls back to file.copy when symlink fails on Unix", {
   skip_on_os("windows")
+  state <- new.env(parent = emptyenv())
+  state$copy_calls <- 0
 
   local_proj_path <- withr::local_tempdir()
   local_cache_path <- withr::local_tempdir()
@@ -109,11 +112,10 @@ test_that("java_install falls back to file.copy when symlink fails on Unix", {
     .package = "base"
   )
 
-  copy_calls <- 0
   local_mocked_bindings(
     file.copy = function(from, to, ...) {
       if (grepl(basename(local_proj_path), to, fixed = TRUE)) {
-        copy_calls <<- copy_calls + 1
+        state$copy_calls <- state$copy_calls + 1
       }
       TRUE
     },
@@ -128,7 +130,7 @@ test_that("java_install falls back to file.copy when symlink fails on Unix", {
     )
   )
 
-  expect_equal(copy_calls, 1)
+  expect_equal(state$copy_calls, 1)
 })
 test_that("java_install respects autoset_java_env = FALSE", {
   skip_on_os("windows") # Uses Linux filename, not applicable on Windows
@@ -171,6 +173,8 @@ test_that("java_install succeeds with mklink junction on Windows", {
   skip_on_os("mac")
   skip_on_os("linux")
   skip_on_os("solaris")
+  state <- new.env(parent = emptyenv())
+  state$system2_args <- list()
 
   local_proj_path <- withr::local_tempdir()
   local_cache_path <- withr::local_tempdir()
@@ -187,10 +191,9 @@ test_that("java_install succeeds with mklink junction on Windows", {
   mock_java_globals()
   local_mocked_bindings(java_env_set = function(...) TRUE)
 
-  system2_args <- list()
   local_mocked_bindings(
     system2 = function(command, args, ...) {
-      system2_args <<- list(command = command, args = args)
+      state$system2_args <- list(command = command, args = args)
       "Junction created for ... " # Simulate success message
     },
     .package = "base"
@@ -202,6 +205,6 @@ test_that("java_install succeeds with mklink junction on Windows", {
     quiet = TRUE
   )
 
-  expect_equal(system2_args$command, "cmd.exe")
-  expect_true(grepl("mklink /J", system2_args$args[2]))
+  expect_equal(state$system2_args$command, "cmd.exe")
+  expect_true(grepl("mklink /J", state$system2_args$args[2]))
 })

--- a/tests/testthat/test-java_list_available.R
+++ b/tests/testthat/test-java_list_available.R
@@ -46,10 +46,10 @@ test_that("java_list_available handles 'all' platform and arch", {
 
 test_that("java_list_available memoization and force parameter work", {
   skip_on_cran()
-
-  call_count <- 0
+  state <- new.env(parent = emptyenv())
+  state$call_count <- 0
   impl_func <- function(p, a) {
-    call_count <<- call_count + 1
+    state$call_count <- state$call_count + 1
     data.frame(
       backend = "native",
       vendor = "Temurin",
@@ -76,7 +76,7 @@ test_that("java_list_available memoization and force parameter work", {
   )
 
   # Reset call count
-  call_count <- 0
+  state$call_count <- 0
 
   # First call
   java_list_available(
@@ -85,7 +85,7 @@ test_that("java_list_available memoization and force parameter work", {
     backend = "native",
     quiet = TRUE
   )
-  expect_equal(call_count, 1)
+  expect_equal(state$call_count, 1)
 
   # Second call (should be memoised)
   java_list_available(
@@ -94,7 +94,7 @@ test_that("java_list_available memoization and force parameter work", {
     backend = "native",
     quiet = TRUE
   )
-  expect_equal(call_count, 1)
+  expect_equal(state$call_count, 1)
 
   # Third call with force = TRUE
   # Note: java_list_available calls forget() on the memoised function it sees in its environment
@@ -105,5 +105,5 @@ test_that("java_list_available memoization and force parameter work", {
     force = TRUE,
     quiet = TRUE
   )
-  expect_equal(call_count, 2)
+  expect_equal(state$call_count, 2)
 })

--- a/tests/testthat/test-java_list_available_impl.R
+++ b/tests/testthat/test-java_list_available_impl.R
@@ -1,34 +1,47 @@
 test_that("list_temurin_versions_impl handles valid data", {
   skip_on_cran()
 
-  # Mock list of major versions
   local_mocked_bindings(
-    java_valid_major_versions_temurin = function() c(17, 21),
+    java_valid_major_versions_temurin = function(...) c(17, 21),
     read_json_url = function(url, ...) {
-      # Return simplified structure as list of lists
-      list(
-        list(
-          version_data = list(
-            semver = "17.0.9+9",
-            openjdk_version = "17.0.9+9"
+      if (grepl("assets/latest/17/", url)) {
+        return(list(
+          list(
+            binary = list(package = list(link = "https://example.com/17.0.9.tar.gz")),
+            version_data = list(
+              semver = "17.0.9+9",
+              openjdk_version = "17.0.9+9"
+            )
+          ),
+          list(
+            binary = list(package = list(link = "https://example.com/17.0.10.tar.gz")),
+            version_data = list(
+              semver = "17.0.10+1",
+              openjdk_version = "17.0.10+1"
+            )
           )
-        ),
-        list(
-          version_data = list(
-            semver = "17.0.10+1",
-            openjdk_version = "17.0.10+1"
+        ))
+      }
+      if (grepl("assets/latest/21/", url)) {
+        return(list(
+          list(
+            binary = list(package = list(link = "https://example.com/21.0.8.tar.gz")),
+            version_data = list(
+              semver = "21.0.8+9",
+              openjdk_version = "21.0.8+9"
+            )
           )
-        )
-      )
+        ))
+      }
+      stop("Unexpected URL")
     },
-    list_temurin_versions_impl = list_temurin_versions_impl
+    .package = "rJavaEnv"
   )
 
-  # Run
   res <- list_temurin_versions_impl(platform = "linux", arch = "x64")
 
   expect_s3_class(res, "data.frame")
-  expect_true(nrow(res) >= 2) # 2 versions for 17, plus whatever mocked for 21 if loop runs
+  expect_true(nrow(res) >= 3)
   expect_equal(res$vendor[1], "Temurin")
   expect_equal(res$backend[1], "native")
 })
@@ -36,7 +49,8 @@ test_that("list_temurin_versions_impl handles valid data", {
 test_that("list_temurin_versions_impl handles empty major versions", {
   skip_on_cran()
   local_mocked_bindings(
-    java_valid_major_versions_temurin = function() NULL
+    java_valid_major_versions_temurin = function(...) NULL,
+    .package = "rJavaEnv"
   )
   res <- list_temurin_versions_impl("linux", "x64")
   expect_s3_class(res, "data.frame")
@@ -46,8 +60,9 @@ test_that("list_temurin_versions_impl handles empty major versions", {
 test_that("list_temurin_versions_impl handles API error gracefully", {
   skip_on_cran()
   local_mocked_bindings(
-    java_valid_major_versions_temurin = function() c(21),
-    read_json_url = function(...) stop("API Error")
+    java_valid_major_versions_temurin = function(...) c(21),
+    read_json_url = function(...) stop("API Error"),
+    .package = "rJavaEnv"
   )
   res <- list_temurin_versions_impl("linux", "x64")
   expect_s3_class(res, "data.frame")

--- a/tests/testthat/test-java_scoped.R
+++ b/tests/testthat/test-java_scoped.R
@@ -77,6 +77,75 @@ test_that("with_rjava_env calls callr::r with correct environment", {
   expect_true(grepl("/mock/java/home/bin", captured_env[["PATH"]]))
 })
 
+test_that("java_subprocess_env configures Linux rJava loader variables", {
+  local_mocked_bindings(
+    Sys.info = function() c(sysname = "Linux"),
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    get_libjvm_path = function(...) "/mock/java/home/lib/server/libjvm.so",
+    .package = "rJavaEnv"
+  )
+
+  withr::with_envvar(c(PATH = "/usr/bin", LD_LIBRARY_PATH = "/usr/lib"), {
+    env_vars <- rJavaEnv:::java_subprocess_env("/mock/java/home", rjava = TRUE)
+
+    expect_equal(env_vars[["JAVA_HOME"]], "/mock/java/home")
+    expect_true(grepl("/mock/java/home/bin", env_vars[["PATH"]]))
+    expect_equal(
+      env_vars[["JAVA_LD_LIBRARY_PATH"]],
+      "/mock/java/home/lib/server"
+    )
+    expect_true(grepl("/mock/java/home/lib/server", env_vars[["LD_LIBRARY_PATH"]]))
+  })
+})
+
+test_that("java_subprocess_env configures macOS DYLD_LIBRARY_PATH for rJava", {
+  local_mocked_bindings(
+    Sys.info = function() c(sysname = "Darwin"),
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    get_libjvm_path = function(...) "/mock/java/home/lib/server/libjvm.dylib",
+    .package = "rJavaEnv"
+  )
+
+  withr::with_envvar(c(PATH = "/usr/bin", DYLD_LIBRARY_PATH = "/usr/lib"), {
+    env_vars <- rJavaEnv:::java_subprocess_env("/mock/java/home", rjava = TRUE)
+
+    expect_equal(env_vars[["JAVA_HOME"]], "/mock/java/home")
+    expect_true(grepl("/mock/java/home/bin", env_vars[["PATH"]]))
+    expect_true(grepl("/mock/java/home/lib/server", env_vars[["DYLD_LIBRARY_PATH"]]))
+  })
+})
+
+test_that("java_subprocess_env leaves Windows at JAVA_HOME and PATH only", {
+  local_mocked_bindings(
+    Sys.info = function() c(sysname = "Windows"),
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    get_libjvm_path = function(...) "C:/Java/bin/server/jvm.dll",
+    .package = "rJavaEnv"
+  )
+
+  withr::with_envvar(c(
+    PATH = "C:/Windows/System32",
+    LD_LIBRARY_PATH = "sentinel-ld",
+    DYLD_LIBRARY_PATH = "sentinel-dyld"
+  ), {
+    env_vars <- rJavaEnv:::java_subprocess_env("C:/Java", rjava = TRUE)
+
+    expect_equal(env_vars[["JAVA_HOME"]], "C:/Java")
+    expect_true(grepl("C:/Java/bin", env_vars[["PATH"]], fixed = TRUE))
+    expect_equal(env_vars[["LD_LIBRARY_PATH"]], "sentinel-ld")
+    expect_equal(env_vars[["DYLD_LIBRARY_PATH"]], "sentinel-dyld")
+  })
+})
+
 test_that("local_java_env uses cache when .use_cache = TRUE", {
   call_count <- 0
   local_mocked_bindings(

--- a/tests/testthat/test-java_scoped.R
+++ b/tests/testthat/test-java_scoped.R
@@ -101,6 +101,46 @@ test_that("java_subprocess_env configures Linux rJava loader variables", {
   })
 })
 
+test_that("java_subprocess_env only updates JAVA_HOME and PATH when rjava is FALSE", {
+  withr::with_envvar(c(
+    PATH = "/usr/bin",
+    LD_LIBRARY_PATH = "sentinel",
+    JAVA_LD_LIBRARY_PATH = "sentinel-java-ld"
+  ), {
+    env_vars <- rJavaEnv:::java_subprocess_env("/mock/java/home", rjava = FALSE)
+
+    expect_equal(env_vars[["JAVA_HOME"]], "/mock/java/home")
+    expect_true(grepl("/mock/java/home/bin", env_vars[["PATH"]]))
+    expect_equal(env_vars[["LD_LIBRARY_PATH"]], "sentinel")
+    expect_equal(env_vars[["JAVA_LD_LIBRARY_PATH"]], "sentinel-java-ld")
+  })
+})
+
+test_that("java_subprocess_env returns base env when libjvm cannot be resolved", {
+  local_mocked_bindings(
+    Sys.info = function() c(sysname = "Linux"),
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    get_libjvm_path = function(...) NULL,
+    .package = "rJavaEnv"
+  )
+
+  withr::with_envvar(c(
+    PATH = "/usr/bin",
+    LD_LIBRARY_PATH = NA,
+    JAVA_LD_LIBRARY_PATH = "sentinel-java-ld"
+  ), {
+    env_vars <- rJavaEnv:::java_subprocess_env("/mock/java/home", rjava = TRUE)
+
+    expect_equal(env_vars[["JAVA_HOME"]], "/mock/java/home")
+    expect_true(grepl("/mock/java/home/bin", env_vars[["PATH"]]))
+    expect_equal(env_vars[["JAVA_LD_LIBRARY_PATH"]], "sentinel-java-ld")
+    expect_false("LD_LIBRARY_PATH" %in% names(env_vars))
+  })
+})
+
 test_that("java_subprocess_env configures macOS DYLD_LIBRARY_PATH for rJava", {
   local_mocked_bindings(
     Sys.info = function() c(sysname = "Darwin"),
@@ -118,6 +158,27 @@ test_that("java_subprocess_env configures macOS DYLD_LIBRARY_PATH for rJava", {
     expect_equal(env_vars[["JAVA_HOME"]], "/mock/java/home")
     expect_true(grepl("/mock/java/home/bin", env_vars[["PATH"]]))
     expect_true(grepl("/mock/java/home/lib/server", env_vars[["DYLD_LIBRARY_PATH"]]))
+  })
+})
+
+test_that("java_subprocess_env handles missing loader path variables", {
+  local_mocked_bindings(
+    Sys.info = function() c(sysname = "Darwin"),
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    get_libjvm_path = function(...) "/mock/java/home/lib/server/libjvm.dylib",
+    .package = "rJavaEnv"
+  )
+
+  withr::with_envvar(c(PATH = "/usr/bin", DYLD_LIBRARY_PATH = NA), {
+    env_vars <- rJavaEnv:::java_subprocess_env("/mock/java/home", rjava = TRUE)
+
+    expect_equal(
+      env_vars[["DYLD_LIBRARY_PATH"]],
+      "/mock/java/home/lib/server"
+    )
   })
 })
 

--- a/tests/testthat/test-java_scoped.R
+++ b/tests/testthat/test-java_scoped.R
@@ -51,17 +51,17 @@ test_that("with_rjava_env requires callr package", {
 
 test_that("with_rjava_env calls callr::r with correct environment", {
   skip_if_not_installed("callr")
+  state <- new.env(parent = emptyenv())
+  state$captured_env <- NULL
 
   local_mocked_bindings(
     java_resolve = function(...) "/mock/java/home",
     .package = "rJavaEnv"
   )
 
-  # Mock callr::r to capture arguments
-  captured_env <- NULL
   local_mocked_bindings(
     r = function(func, args, libpath, env, show) {
-      captured_env <<- env
+      state$captured_env <- env
       func()
     },
     .package = "callr"
@@ -73,8 +73,8 @@ test_that("with_rjava_env calls callr::r with correct environment", {
     quiet = TRUE
   )
 
-  expect_equal(captured_env[["JAVA_HOME"]], "/mock/java/home")
-  expect_true(grepl("/mock/java/home/bin", captured_env[["PATH"]]))
+  expect_equal(state$captured_env[["JAVA_HOME"]], "/mock/java/home")
+  expect_true(grepl("/mock/java/home/bin", state$captured_env[["PATH"]]))
 })
 
 test_that("java_subprocess_env configures Linux rJava loader variables", {
@@ -147,10 +147,11 @@ test_that("java_subprocess_env leaves Windows at JAVA_HOME and PATH only", {
 })
 
 test_that("local_java_env uses cache when .use_cache = TRUE", {
-  call_count <- 0
+  state <- new.env(parent = emptyenv())
+  state$call_count <- 0
   local_mocked_bindings(
     java_resolve = function(..., .use_cache = FALSE) {
-      call_count <<- call_count + 1
+      state$call_count <- state$call_count + 1
       "/mock/java/home"
     },
     .package = "rJavaEnv"
@@ -161,7 +162,7 @@ test_that("local_java_env uses cache when .use_cache = TRUE", {
     rJavaEnv::local_java_env(version = 21, .use_cache = TRUE, quiet = TRUE)
   })
 
-  first_count <- call_count
+  first_count <- state$call_count
 
   # Second call - java_resolve should still be called but with .use_cache = TRUE
   local({
@@ -169,5 +170,5 @@ test_that("local_java_env uses cache when .use_cache = TRUE", {
   })
 
   # Both calls happen, but .use_cache = TRUE is passed through
-  expect_equal(call_count, 2)
+  expect_equal(state$call_count, 2)
 })

--- a/tests/testthat/test-java_valid_versions_extra.R
+++ b/tests/testthat/test-java_valid_versions_extra.R
@@ -314,6 +314,22 @@ test_that("java_valid_major_versions_temurin uses shipped fallback when probes f
   expect_equal(versions, fallback)
 })
 
+test_that("java_valid_major_versions_temurin returns empty when probes succeed without assets", {
+  local_mocked_bindings(
+    read_json_url = function(url, max_simplify_lvl = "data_frame") {
+      if (grepl("info/available_releases", url)) {
+        return(list(available_releases = c(17, 21)))
+      }
+      list()
+    },
+    .package = "rJavaEnv"
+  )
+
+  versions <- java_valid_major_versions_temurin(platform = "linux", arch = "x64")
+
+  expect_identical(versions, character(0))
+})
+
 # Test java_valid_major_versions_corretto with explicit platform/arch
 test_that("java_valid_major_versions_corretto works with explicit parameters", {
   skip_on_cran()

--- a/tests/testthat/test-java_valid_versions_extra.R
+++ b/tests/testthat/test-java_valid_versions_extra.R
@@ -209,6 +209,111 @@ test_that("java_valid_versions saves results to session and file cache", {
   expect_true(file.exists(expected_file))
 })
 
+test_that("java_valid_major_versions_temurin filters summary versions by assets", {
+  local_mocked_bindings(
+    read_json_url = function(url, max_simplify_lvl = "data_frame") {
+      if (grepl("info/available_releases", url)) {
+        return(list(available_releases = c(8, 11, 21)))
+      }
+      if (grepl("assets/latest/8/", url)) {
+        return(list(list(
+          binary = list(package = list(link = "https://example.com/8.tar.gz")),
+          version_data = list(semver = "8.0.452+9", openjdk_version = "8.0.452")
+        )))
+      }
+      if (grepl("assets/latest/11/", url)) {
+        return(list())
+      }
+      if (grepl("assets/latest/21/", url)) {
+        return(list(list(
+          binary = list(package = list(link = "https://example.com/21.tar.gz")),
+          version_data = list(semver = "21.0.8+9", openjdk_version = "21.0.8")
+        )))
+      }
+      stop("Unexpected URL")
+    },
+    .package = "rJavaEnv"
+  )
+
+  versions <- java_valid_major_versions_temurin(platform = "linux", arch = "x64")
+
+  expect_equal(versions, c("8", "21"))
+})
+
+test_that("java_valid_major_versions_temurin falls back from empty summary", {
+  local_mocked_bindings(
+    read_json_url = function(url, max_simplify_lvl = "data_frame") {
+      if (grepl("info/available_releases", url)) {
+        return(list(available_releases = integer(0)))
+      }
+      if (grepl("assets/latest/17/", url)) {
+        return(list(list(
+          binary = list(package = list(link = "https://example.com/17.tar.gz")),
+          version_data = list(semver = "17.0.16+8", openjdk_version = "17.0.16")
+        )))
+      }
+      if (grepl("assets/latest/21/", url)) {
+        return(list(list(
+          binary = list(package = list(link = "https://example.com/21.tar.gz")),
+          version_data = list(semver = "21.0.8+9", openjdk_version = "21.0.8")
+        )))
+      }
+      list()
+    },
+    .package = "rJavaEnv"
+  )
+
+  expect_message(
+    versions <- java_valid_major_versions_temurin(platform = "linux", arch = "x64"),
+    "summary endpoint returned no usable major versions"
+  )
+
+  expect_equal(versions, c("17", "21"))
+})
+
+test_that("java_valid_major_versions_temurin handles malformed summary payload", {
+  local_mocked_bindings(
+    read_json_url = function(url, max_simplify_lvl = "data_frame") {
+      if (grepl("info/available_releases", url)) {
+        return(list(tip_version = 27))
+      }
+      if (grepl("assets/latest/25/", url)) {
+        return(list(list(
+          binary = list(package = list(link = "https://example.com/25.tar.gz")),
+          version_data = list(semver = "25.0.2+10", openjdk_version = "25.0.2")
+        )))
+      }
+      list()
+    },
+    .package = "rJavaEnv"
+  )
+
+  expect_message(
+    versions <- java_valid_major_versions_temurin(platform = "linux", arch = "x64"),
+    "summary endpoint returned no usable major versions"
+  )
+
+  expect_equal(versions, "25")
+})
+
+test_that("java_valid_major_versions_temurin uses shipped fallback when probes fail", {
+  local_mocked_bindings(
+    read_json_url = function(...) stop("Network down"),
+    .package = "rJavaEnv"
+  )
+
+  fallback <- temurin_candidate_versions("linux", "x64")
+
+  expect_warning(
+    versions <- suppressMessages(
+      java_valid_major_versions_temurin(platform = "linux", arch = "x64")
+    ),
+    "Returning shipped fallback versions"
+  )
+
+  expect_equal(versions, fallback)
+})
+
 # Test java_valid_major_versions_corretto with explicit platform/arch
 test_that("java_valid_major_versions_corretto works with explicit parameters", {
   skip_on_cran()

--- a/tests/testthat/test-java_valid_versions_temurin.R
+++ b/tests/testthat/test-java_valid_versions_temurin.R
@@ -1,14 +1,12 @@
-test_that("java_valid_major_versions_temurin returns versions", {
+test_that("java_valid_major_versions_temurin returns package-validated versions", {
   skip_on_cran()
   skip_if_offline()
 
-  # This tests the live API
   versions <- java_valid_major_versions_temurin()
 
   expect_type(versions, "character")
   expect_true(length(versions) > 0)
-  # Basic checks for known LTS versions
-  expect_true(any(c("8", "11", "17", "21") %in% versions))
+  expect_true(any(c("11", "17", "21", "25") %in% versions))
 })
 
 test_that("java_valid_versions supports Temurin distribution", {
@@ -18,4 +16,5 @@ test_that("java_valid_versions supports Temurin distribution", {
   versions <- java_valid_versions(distribution = "Temurin", force = TRUE)
   expect_type(versions, "character")
   expect_true(length(versions) > 0)
+  expect_true(any(c("11", "17", "21", "25") %in% versions))
 })

--- a/tests/testthat/test-use_java.R
+++ b/tests/testthat/test-use_java.R
@@ -102,6 +102,8 @@ test_that("use_java cache hit outputs messages when quiet = FALSE", {
 
 # Test use_java cache miss - triggers download path
 test_that("use_java downloads when version not in cache", {
+  state <- new.env(parent = emptyenv())
+  state$download_called <- FALSE
   cache_path <- withr::local_tempdir()
 
   local_mocked_bindings(
@@ -124,10 +126,9 @@ test_that("use_java downloads when version not in cache", {
     .package = "rJavaEnv"
   )
 
-  download_called <- FALSE
   local_mocked_bindings(
     java_download = function(...) {
-      download_called <<- TRUE
+      state$download_called <- TRUE
       file.path(cache_path, "fake-distrib.tar.gz")
     },
     .package = "rJavaEnv"
@@ -151,7 +152,7 @@ test_that("use_java downloads when version not in cache", {
     quiet = TRUE
   )
 
-  expect_true(download_called)
+  expect_true(state$download_called)
   expect_true(result)
 })
 


### PR DESCRIPTION
## Summary
Harden Temurin version discovery by validating the summary endpoint response and confirming majors against downloadable Temurin assets.
Rework rJava version checks to use a shared subprocess Java environment, prefer `callr` when available, and keep an `Rscript` fallback with the same env contract.
Update the live-test workflow and test suite so package behavior, subprocess isolation, and Temurin fallback paths are covered consistently.

## Verification
Run `Rscript -e 'devtools::test(stop_on_failure = FALSE)'`
Expected local result: `[ FAIL 0 | WARN 0 | SKIP 61 | PASS 519 ]`
